### PR TITLE
Implement default fixtures.

### DIFF
--- a/build/vm_setup.sh
+++ b/build/vm_setup.sh
@@ -7,7 +7,7 @@ sudo apt-get update
 sudo debconf-set-selections <<< 'mysql-server mysql-server/root_password password root'
 sudo debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password root'
 
-sudo apt-get install -y curl apache2 libapache2-mod-fastcgi php5 php5-fpm php5-cli php5-curl php5-gd php5-mcrypt php5-mysql mysql-server
+sudo apt-get install -y curl apache2 libapache2-mod-fastcgi php5 php5-fpm php5-cli php5-curl php5-gd php5-mcrypt php5-mysql phpt5-xdebug mysql-server
 
 sudo sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php5/fpm/php.ini
 sudo sed -i "s/display_errors = .*/display_errors = On/" /etc/php5/fpm/php.ini
@@ -40,6 +40,15 @@ sudo echo "<VirtualHost *:80>
   </IfModule>
 
 </VirtualHost>" | sudo tee /etc/apache2/sites-available/default > /dev/null
+
+sudo bash -c "cat >> /etc/php5/conf.d/xdebug.ini <<EOF
+xdebug.default_enable = 1
+xdebug.remote_autostart = 1
+xdebug.remote_connect_back = 1
+xdebug.remote_enable = 1
+xdebug.remote_handler = "dbgp"
+xdebug.remote_port = 9000
+EOF"
 
 sudo service apache2 restart
 sudo service php5-fpm restart

--- a/src/MageTest/Manager/FixtureManager.php
+++ b/src/MageTest/Manager/FixtureManager.php
@@ -179,7 +179,7 @@ class FixtureManager
      */
     private function getDefaultFixtureTemplate($fixtureType)
     {
-        $filePath = getcwd() . '/src/MageTest/Manager/Fixtures/';
+        $filePath = __DIR__ . '/Fixtures/';
         switch($fixtureType)
         {
             case 'customer/address': return $filePath . 'Address.yml';

--- a/tests/MageTest/Manager/AddressTest.php
+++ b/tests/MageTest/Manager/AddressTest.php
@@ -8,8 +8,7 @@ class AddressTest extends WebTestCase
     protected function setUp()
     {
         parent::setUp();
-        $fixture = getcwd() . '/src/MageTest/Manager/Fixtures/Address.yml';
-        $this->addressFixture = $this->manager->loadFixture($fixture);
+        $this->addressFixture = $this->manager->loadFixture('customer/address');
     }
 
     public function testAssignAddressToCustomer()

--- a/tests/MageTest/Manager/CustomerTest.php
+++ b/tests/MageTest/Manager/CustomerTest.php
@@ -25,27 +25,35 @@ class CustomerTest extends WebTestCase
     protected function setUp()
     {
         parent::setUp();
-        $fixture = getcwd() . '/src/MageTest/Manager/Fixtures/Customer.yml';
-        $this->customerFixture = $this->manager->loadFixture($fixture);
     }
 
-    public function testCreatesCustomer()
+    public function testCreatesCustomerDefault()
     {
-        $this->customerFixture = $this->manager->getFixture('customer/customer');
+        $this->customerFixture = $this->manager->loadFixture('customer/customer');
 
         $this->customerLogin($this->customerFixture->getEmail(), $this->customerFixture->getPassword());
 
         $this->assertSession()->addressEquals('/customer/account/');
     }
 
-    public function testDeletesCustomer()
+    public function testDeletesCustomerDefault()
     {
-        $this->customerFixture = $this->manager->getFixture('customer/customer');
+        $this->customerFixture = $this->manager->loadFixture('customer/customer');
 
         $this->manager->clear();
 
         $this->customerLogin($this->customerFixture->getEmail(), $this->customerFixture->getPassword());
 
         $this->assertSession()->addressEquals('/customer/account/login/');
+    }
+
+    public function testCreatesUserDefinedCustomer()
+    {
+        $this->customerFixture = $this->manager->loadFixture('customer/customer',
+            getcwd() . '/tests/MageTest/Manager/Fixtures/Customer.yml');
+
+        $this->customerLogin($this->customerFixture->getEmail(), $this->customerFixture->getPassword());
+
+        $this->assertSession()->addressEquals('/customer/account/');
     }
 }

--- a/tests/MageTest/Manager/Fixtures/Customer.yml
+++ b/tests/MageTest/Manager/Fixtures/Customer.yml
@@ -1,0 +1,8 @@
+customer/customer:
+    firstname: test-user-defined
+    lastname: test-user-defined
+    email: customer@example.com
+    password: 123123pass
+    website_id: 1
+    store: 1
+    status: 1

--- a/tests/MageTest/Manager/OrderTest.php
+++ b/tests/MageTest/Manager/OrderTest.php
@@ -8,8 +8,7 @@ class OrderTest extends WebTestCase
     protected function setUp()
     {
         parent::setUp();
-        $fixture = getcwd() . '/src/MageTest/Manager/Fixtures/Order.yml';
-        $this->orderFixture = $this->manager->loadFixture($fixture);
+        $this->orderFixture = $this->manager->loadFixture('sales/quote');
     }
 
     public function testCreateOrderWithOneProduct()

--- a/tests/MageTest/Manager/ProductTest.php
+++ b/tests/MageTest/Manager/ProductTest.php
@@ -1,8 +1,6 @@
 <?php
 namespace MageTest\Manager;
 
-use MageTest\Manager\Attributes\Provider\YamlProvider;
-
 class ProductTest extends WebTestCase
 {
     private $productFixture;
@@ -10,8 +8,7 @@ class ProductTest extends WebTestCase
     protected function setUp()
     {
         parent::setUp();
-        $fixture = getcwd() . '/src/MageTest/Manager/Fixtures/Product.yml';
-        $this->productFixture = $this->manager->loadFixture($fixture);
+        $this->productFixture = $this->manager->loadFixture('catalog/product');
     }
 
     public function testCreateSimpleProduct()


### PR DESCRIPTION
The calling of default fixtures is now less cumbersome. 

When you instantiate the manger, you can pass in the default model type, and the YAML fixtures will be called.
`manager->loadFixture('customer/customer');`

You can also specify the full path of the fixture file, if it needs to be user defined
`manager->loadFixture('customer/customer', '/path/to/customer.yml');`
