### PR TITLE
Add default builder. Use category as an example

### DIFF
--- a/src/MageTest/Manager/Builders/General.php
+++ b/src/MageTest/Manager/Builders/General.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace MageTest\Manager\Builders;
+
+/**
+ * Class General
+ * @package MageTest\Manager\Builders
+ */
+class General extends AbstractBuilder implements BuilderInterface
+{
+    /**
+     * @return \Mage_Core_Model_Abstract
+     */
+    public function build()
+    {
+        return $this->model->addData($this->attributes);
+    }
+}

--- a/src/MageTest/Manager/FixtureManager.php
+++ b/src/MageTest/Manager/FixtureManager.php
@@ -149,6 +149,7 @@ class FixtureManager
             case 'customer/customer': return $this->builders[$modelType] = new Builders\Customer($modelType);
             case 'catalog/product': return $this->builders[$modelType] = new Builders\Product($modelType);
             case 'sales/quote': return $this->builders[$modelType] = new Builders\Order($modelType);
+            default : return $this->builders[$modelType] = new Builders\General($modelType);
         }
     }
 

--- a/tests/MageTest/Manager/CategoryTest.php
+++ b/tests/MageTest/Manager/CategoryTest.php
@@ -25,11 +25,20 @@ class CategoryTest extends WebTestCase
         parent::setUp();
     }
 
-    public function testCreateCategory()
+    public function testCreateCategoryViaId()
     {
         $categoryFixture = $this->manager->loadFixture('catalog/category', __DIR__ . '/Fixtures/Category.yml');
 
         $this->getSession()->visit(getenv('BASE_URL') . '/catalog/category/view/id/' . $categoryFixture->getId());
+
+        $this->assertSession()->statusCodeEquals(200);
+    }
+
+    public function testCreateCategoryViaUrlKey()
+    {
+        $categoryFixture = $this->manager->loadFixture('catalog/category', __DIR__ . '/Fixtures/Category.yml');
+
+        $this->getSession()->visit(getenv('BASE_URL') . '/' . $categoryFixture->getUrlKey() . '.html');
 
         $this->assertSession()->statusCodeEquals(200);
     }

--- a/tests/MageTest/Manager/CategoryTest.php
+++ b/tests/MageTest/Manager/CategoryTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Manager
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License, that is bundled with this
+ * package in the file LICENSE.
+ * It is also available through the world-wide-web at this URL:
+ *
+ * http://opensource.org/licenses/MIT
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email
+ * to <magetest@sessiondigital.com> so we can send you a copy immediately.
+ *
+ * @copyright  Copyright (c) 2014 MageTest team and contributors.
+ */
+namespace MageTest\Manager;
+
+class CategoryTest extends WebTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+    }
+
+    public function testCreateCategory()
+    {
+        $categoryFixture = $this->manager->loadFixture('catalog/category', __DIR__ . '/Fixtures/Category.yml');
+
+        $this->getSession()->visit(getenv('BASE_URL') . '/catalog/category/view/id/' . $categoryFixture->getId());
+
+        $this->assertSession()->statusCodeEquals(200);
+    }
+}

--- a/tests/MageTest/Manager/CustomerTest.php
+++ b/tests/MageTest/Manager/CustomerTest.php
@@ -49,8 +49,7 @@ class CustomerTest extends WebTestCase
 
     public function testCreatesUserDefinedCustomer()
     {
-        $this->customerFixture = $this->manager->loadFixture('customer/customer',
-            getcwd() . '/tests/MageTest/Manager/Fixtures/Customer.yml');
+        $this->customerFixture = $this->manager->loadFixture('customer/customer', __DIR__ . '/Fixtures/Customer.yml');
 
         $this->customerLogin($this->customerFixture->getEmail(), $this->customerFixture->getPassword());
 

--- a/tests/MageTest/Manager/Fixtures/Category.yml
+++ b/tests/MageTest/Manager/Fixtures/Category.yml
@@ -1,0 +1,9 @@
+#creates root catalog (id=3) therefore path=1/3
+catalog/category:
+    name: Test Category
+    url_key: test-category
+    path: 1/3
+    is_active: 1
+    is_anchor: 1
+    include_in_menu: 1
+    display_mode: PRODUCTS


### PR DESCRIPTION
A general builder is now implemented. The is for models that don't need any specific model methods to be called in the creation of the model (which is required for product/order etc...)

The example test here is for a test category.

This can be used to instantiate models for project specific extensions being built as well.
