### PR TITLE
Set stock item to product in Product Builder

### DIFF
--- a/src/MageTest/Manager/Builders/Product.php
+++ b/src/MageTest/Manager/Builders/Product.php
@@ -13,6 +13,7 @@ class Product extends AbstractBuilder implements BuilderInterface
      */
     public function build()
     {
+        $this->model->setStockItem(\Mage::getModel('cataloginventory/stock_item'));
         return $this->model->addData($this->attributes);
     }
 }


### PR DESCRIPTION
Assigns stock item to product instance before save, otherwise the newly created stock item instance (in catalog inventory module) won't be assigned to the product.
