### PR TITLE
Fix #16: Provide array to override default attributes

### DIFF
--- a/src/MageTest/Manager/FixtureManager.php
+++ b/src/MageTest/Manager/FixtureManager.php
@@ -55,7 +55,7 @@ class FixtureManager
         $modelAttributes = $attributesProvider->readAttributes();
 
         if(!is_null($overrideAttributes)) {
-            $modelAttributes = array_replace($attributesProvider->readAttributes(), $overrideAttributes);
+            $modelAttributes = array_replace($modelAttributes, $overrideAttributes);
         }
 
         $builder = $this->getBuilder($attributesProvider->getModelType());

--- a/src/MageTest/Manager/FixtureManager.php
+++ b/src/MageTest/Manager/FixtureManager.php
@@ -38,7 +38,7 @@ class FixtureManager
      * @param $fixtureFile
      * @return mixed
      */
-    public function loadFixture($fixtureType, $userFixtureFile = null)
+    public function loadFixture($fixtureType, $userFixtureFile = null, $overrideAttributes = null)
     {
         $attributesProvider = clone $this->attributesProvider;
 
@@ -52,8 +52,14 @@ class FixtureManager
             $attributesProvider->readFile($fixtureFile);
         }
 
+        $modelAttributes = $attributesProvider->readAttributes();
+
+        if(!is_null($overrideAttributes)) {
+            $modelAttributes = array_replace($attributesProvider->readAttributes(), $overrideAttributes);
+        }
+
         $builder = $this->getBuilder($attributesProvider->getModelType());
-        $builder->setAttributes($attributesProvider->readAttributes());
+        $builder->setAttributes($modelAttributes);
 
         if($attributesProvider->hasFixtureDependencies())
         {

--- a/tests/MageTest/Manager/ProductTest.php
+++ b/tests/MageTest/Manager/ProductTest.php
@@ -8,11 +8,13 @@ class ProductTest extends WebTestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->productFixture = $this->manager->loadFixture('catalog/product');
+
     }
 
     public function testCreateSimpleProduct()
     {
+        $this->productFixture = $this->manager->loadFixture('catalog/product');
+
         $session = $this->getSession();
         $session->visit(getenv('BASE_URL') . '/catalog/product/view/id/' . $this->productFixture->getId());
         $this->assertSession()->statusCodeEquals(200);
@@ -20,6 +22,8 @@ class ProductTest extends WebTestCase
 
     public function testDeleteSimpleProduct()
     {
+        $this->productFixture = $this->manager->loadFixture('catalog/product');
+
         $this->manager->clear();
 
         $session = $this->getSession();
@@ -29,6 +33,8 @@ class ProductTest extends WebTestCase
 
     public function testCreateSimpleProductWithImage()
     {
+        $this->productFixture = $this->manager->loadFixture('catalog/product');
+
         $imageURL = getcwd() . '/tests/MageTest/Manager/Assets/370x370.jpg';
 
         $this->productFixture->setMediaGallery (array('images'=>array (), 'values'=>array ()));
@@ -38,5 +44,18 @@ class ProductTest extends WebTestCase
         $session = $this->getSession();
         $session->visit(getenv('BASE_URL') . '/catalog/product/view/id/' . $this->productFixture->getId());
         $this->assertSession()->elementExists('css', '#image');
+    }
+
+    public function testOverrideDefaultValues()
+    {
+        $this->productFixture = $this->manager->loadFixture('catalog/product', null, array(
+            'name' => 'Overridden Product Name',
+        ));
+
+        $session = $this->getSession();
+        $session->visit(getenv('BASE_URL') . '/catalog/product/view/id/' . $this->productFixture->getId());
+
+        $this->assertSession()->pageTextContains('Overridden Product Name');
+        $this->assertSession()->statusCodeEquals(200);
     }
 }


### PR DESCRIPTION
I think this addresses #16 nicely. Repurposing the yaml file seemed overkill. Just using an array replace if an array is passed. 

See test for usage.

Feedback welcome :)
