### PR TITLE
Pass the yaml file contents to Yaml::parse to prevent deprecated warning

### DIFF
--- a/src/MageTest/Manager/Attributes/Provider/YamlProvider.php
+++ b/src/MageTest/Manager/Attributes/Provider/YamlProvider.php
@@ -20,7 +20,7 @@ class YamlProvider implements ProviderInterface
      */
     public function readFile($file)
     {
-        $this->yaml = Yaml::parse($file);
+        $this->yaml = Yaml::parse(file_get_contents($file));
     }
 
     /**


### PR DESCRIPTION
From 2.2 parsing a filename to Yaml::parse is deprecated and triggers a php warning.
The file contents should be given instead.
